### PR TITLE
Feature | Adding Validation to Video Url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'turbolinks_render'
-gem "validate_url"
 
 # Seeds with Faker
 gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'autoprefixer-rails', '10.2.5'
 gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'turbolinks_render'
+gem "validate_url"
 
 # Seeds with Faker
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    public_suffix (4.0.7)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -227,6 +228,9 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     uniform_notifier (1.14.2)
+    validate_url (1.0.13)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -274,6 +278,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   turbolinks_render
   tzinfo-data
+  validate_url
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
 
@@ -281,4 +286,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.30
+   2.3.11

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,6 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.7)
     puma (5.3.2)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -228,9 +227,6 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     uniform_notifier (1.14.2)
-    validate_url (1.0.13)
-      activemodel (>= 3.0.0)
-      public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -278,7 +274,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   turbolinks_render
   tzinfo-data
-  validate_url
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -7,4 +7,5 @@ class Institution < ApplicationRecord
   validates :name, presence: true
   validates :website_url, presence: true
   validates :logo, presence: true
+  validates :video_url, url: true
 end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -7,5 +7,5 @@ class Institution < ApplicationRecord
   validates :name, presence: true
   validates :website_url, presence: true
   validates :logo, presence: true
-  validates :video_url, url: true
+  validates :video_url, format: { with: URI::regexp(%w[http https]) }
 end

--- a/app/models/policy_making.rb
+++ b/app/models/policy_making.rb
@@ -10,8 +10,8 @@ class PolicyMaking < ApplicationRecord
 
   validates :content, presence: true
   validates :country, uniqueness: { scope: :topic }
-  validates :video_url, url: true
-
+  validates :video_url, format: { with: URI::regexp(%w[http https]) }
+ 
   def question(scope)
     questions.find_by(scope: scope)
   end

--- a/app/models/policy_making.rb
+++ b/app/models/policy_making.rb
@@ -10,7 +10,7 @@ class PolicyMaking < ApplicationRecord
 
   validates :content, presence: true
   validates :country, uniqueness: { scope: :topic }
-  validates :video_url, url: true
+  # validates :video_url, url: true
 
   def question(scope)
     questions.find_by(scope: scope)

--- a/app/models/policy_making.rb
+++ b/app/models/policy_making.rb
@@ -10,7 +10,7 @@ class PolicyMaking < ApplicationRecord
 
   validates :content, presence: true
   validates :country, uniqueness: { scope: :topic }
-  # validates :video_url, url: true
+  validates :video_url, url: true
 
   def question(scope)
     questions.find_by(scope: scope)

--- a/app/models/policy_making.rb
+++ b/app/models/policy_making.rb
@@ -10,6 +10,7 @@ class PolicyMaking < ApplicationRecord
 
   validates :content, presence: true
   validates :country, uniqueness: { scope: :topic }
+  validates :video_url, url: true
 
   def question(scope)
     questions.find_by(scope: scope)

--- a/app/models/policy_plan.rb
+++ b/app/models/policy_plan.rb
@@ -7,4 +7,5 @@ class PolicyPlan < ApplicationRecord
   validates :content, presence: true
   validates :short_description, presence: true
   validates :goals, inclusion: { in: [true, false] }
+  validates :video_url, url: true
 end

--- a/app/models/policy_plan.rb
+++ b/app/models/policy_plan.rb
@@ -7,5 +7,5 @@ class PolicyPlan < ApplicationRecord
   validates :content, presence: true
   validates :short_description, presence: true
   validates :goals, inclusion: { in: [true, false] }
-  validates :video_url, url: true
+  validates :video_url, format: { with: URI::regexp(%w[http https]) }
 end


### PR DESCRIPTION
## What was changed

- [x] - added validate_url gem
- [x] - add validations to all video_urls

## How to test it?
1. Go to http://localhost:3000/policy_makings/X/edit
2. Try to update the video_url to something strange
3. Should see a validation error

## Considerations
The users now needs to add the url with http or https, like so: "https://www.youtube.com/embed/Uv9URjIBtUQ". Otherwise it won't be validated. 